### PR TITLE
Fixes Issue 61 and 135 - Conflicting subscriptions association in subscriber [User generally] model

### DIFF
--- a/app/models/commontator/thread.rb
+++ b/app/models/commontator/thread.rb
@@ -91,7 +91,7 @@ module Commontator
 
     def subscription_for(subscriber)
       return nil if !subscriber || !subscriber.is_commontator
-      subscriber.subscriptions.where(thread_id: self.id).first
+      subscriber.commontator_subscriptions.where(thread_id: self.id).first
     end
 
     def subscribe(subscriber)

--- a/lib/commontator/acts_as_commontator.rb
+++ b/lib/commontator/acts_as_commontator.rb
@@ -7,7 +7,7 @@ module Commontator
       base.is_commontator = false
       base.extend(ClassMethods)
     end
-    
+
     module ClassMethods
       def acts_as_commontator(options = {})
         class_eval do
@@ -17,12 +17,12 @@ module Commontator
 
           has_many :comments,      as: :creator,
                                    class_name: 'Commontator::Comment'
-          has_many :subscriptions, as: :subscriber,
+          has_many :commontator_subscriptions, as: :subscriber,
                                    class_name: 'Commontator::Subscription',
                                    dependent: :destroy
         end
       end
-      
+
       alias_method :acts_as_commonter, :acts_as_commontator
       alias_method :acts_as_commentator, :acts_as_commontator
       alias_method :acts_as_commenter, :acts_as_commontator

--- a/spec/lib/commontator/acts_as_commontator_spec.rb
+++ b/spec/lib/commontator/acts_as_commontator_spec.rb
@@ -17,7 +17,7 @@ module Commontator
     it 'must modify models that act_as_commontator' do
       user = DummyUser.create
       expect(user).to respond_to(:comments)
-      expect(user).to respond_to(:subscriptions)
+      expect(user).to respond_to(:commontator_subscriptions)
       expect(user).to respond_to(:commontator_config)
       expect(user.commontator_config).to be_a(CommontatorConfig)
     end


### PR DESCRIPTION
Change the injected `subscriptions` association to `commontator_subscriptions` to avoid conflict with existing `subscriptions` model and association in `subscriber` model usually [User]

It should not break existing apps as change is internal to gem and should not affect apps already using them unless they are relying on the `subscriptions` association added by `commentator gem` in `subscriber` model somehow.

Fix is simple grep `subscriptions` and replace `commentator_subscriptions` but still with a careful inspection to not change unrelated `subscriptions` text :wink: 